### PR TITLE
Actually use the column property instead of hardcoded 8.

### DIFF
--- a/lib/src/emoji_keyboard_widget.dart
+++ b/lib/src/emoji_keyboard_widget.dart
@@ -137,7 +137,7 @@ class EmojiKeyboard extends StatelessWidget {
                             key: ValueKey(index),
                             gridDelegate:
                                 SliverGridDelegateWithFixedCrossAxisCount(
-                              crossAxisCount: 8,
+                              crossAxisCount: column,
                             ),
                             delegate: SliverChildListDelegate.fixed(
                               snapshot.data[index ~/ 2].map((Emoji emoji) {


### PR DESCRIPTION
Actually use the column property instead of hardcoded 8.

Fixes #10 